### PR TITLE
Implemented ejsOptions.parentPath as relativePath to project

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,8 +3,11 @@ var path = require('path');
 
 var createTemplateName = function (basePath, parentPath, filePath) {	
 	var extensionRegex = /(\.[a-z]+)+$/;
-	var absolutePath = path.join(basePath, parentPath) + '/';
-	var templateName = filePath.replace(absolutePath, '')
+	var absolutePath = path.join(basePath, parentPath);
+	var normalizedAbsolutePath = absolutePath.lastIndexOf('/') == absolutePath.length - 1 
+					? absolutePath
+					: absolutePath + '/';
+	var templateName = filePath.replace(normalizedAbsolutePath, '')
 				   .replace(extensionRegex, '');
 	
 	return templateName;

--- a/index.js
+++ b/index.js
@@ -1,20 +1,25 @@
 var ejs = require('ejs');
+var path = require('path');
 
-var createEjsPreprocessor = function(logger, ejsOptions) {
+var createTemplateName = function (basePath, parentPath, filePath) {	
+	var extensionRegex = /(\.[a-z]+)+$/;
+	var absolutePath = path.join(basePath, parentPath) + '/';
+	var templateName = filePath.replace(absolutePath, '')
+				   .replace(extensionRegex, '');
+	
+	return templateName;
+};
+
+var createEjsPreprocessor = function(logger, basePath, ejsOptions) {
     var log = logger.create('preprocessor.ejs');
 
     return function(content, file, done) {
         var processed = null;
 
-        log.debug('Read option parentPath: ', ejsOptions.parentPath);
-        var templateName = file.originalPath.replace(ejsOptions.parentPath, '');
-        // Remove all extensions. For
-        //     parentPath: /Users/our_user/our_project/app/assets/javascripts/templates
-        // /Users/our_user/our_project/app/assets/javascripts/templates/cars/bmw_template.jst.ejs
-        //     becomes `cars/bmw_template`
-        templateName = templateName.replace(/(\.[a-z]+)+$/, '');
-        // "/activity/activity_list_change.jst.ejs"
-        log.debug('Processing "%s".', file.originalPath);
+	var templateName = createTemplateName(basePath, ejsOptions.parentPath, file.originalPath);
+
+        log.debug('Processing "%s".', templateName);
+
         try {
             processed = "\
               (function() {\
@@ -30,7 +35,7 @@ var createEjsPreprocessor = function(logger, ejsOptions) {
     };
 };
 
-createEjsPreprocessor.$inject = ['logger', 'config.ejsOptions'];
+createEjsPreprocessor.$inject = ['logger', 'config.basePath', 'config.ejsOptions'];
 
 module.exports = {
     'preprocessor:ejs': ['factory', createEjsPreprocessor]


### PR DESCRIPTION
Added possibility to write parentPath in config as:
    'app/assets/javascripts' or 'app/assets/javascripts/'
instead of 
     '/home/{user}/../{app_name}/app/assets/javascripts/'

so specs can be run from any disk location without needing to modify the configuration, possibly another developer/build server
