### PR TITLE
Add compile options

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,21 @@ directive, and in the `ejsOptions` add a path (absolute) to the location of your
         '**/*.ejs': ['ejs']
     },
     ejsOptions: {
-        parentPath: 'app/assets/javascripts/templates/'
+        parentPath: 'app/assets/javascripts/templates/',
+        compileOptions: {
+            // See https://github.com/tj/ejs#options for more options
+            open: '{{',
+            close: '}}',
+
+            // An example of passing helper function that the EJS files can use.
+            helpMe: function () {
+                return 'Help!!';
+            }
+        }
     },
     [...]
 
-The `parentPath` is relative to the `basePath` specified in your config. 
+The `parentPath` is relative to the `basePath` specified in your config.
 
 The `JST` global variable will contain keys relative to `parentPath` for your templates. E.g. for
 the file `/Users/sebi/devel/super_site/app/assets/javascripts/templates/homepage/header.ejs`, by

--- a/index.js
+++ b/index.js
@@ -1,19 +1,19 @@
 var ejs = require('ejs');
 var path = require('path');
 
-var createTemplateName = function (basePath, parentPath, filePath) {	
+var createTemplateName = function (basePath, parentPath, filePath) {
 	var extensionRegex = /(\.[a-z]+)+$/;
 	var absolutePath = path.join(basePath, parentPath);
-	var normalizedAbsolutePath = absolutePath.lastIndexOf('/') == absolutePath.length - 1 
+	var normalizedAbsolutePath = absolutePath.lastIndexOf('/') == absolutePath.length - 1
 					? absolutePath
 					: absolutePath + '/';
 	var templateName = filePath.replace(normalizedAbsolutePath, '')
 				   .replace(extensionRegex, '');
-	
+
 	return templateName;
 };
 
-var createEjsPreprocessor = function(logger, basePath, ejsOptions) {
+var createEjsPreprocessor = function(logger, helper, basePath, ejsOptions) {
     var log = logger.create('preprocessor.ejs');
 
     return function(content, file, done) {
@@ -28,7 +28,7 @@ var createEjsPreprocessor = function(logger, basePath, ejsOptions) {
               (function() {\
                 this.JST || (this.JST = {});\
                 this.JST['" + templateName +
-                  "'] = " + ejs.compile(content, {client: true}) +
+                  "'] = " + ejs.compile(content, helper.merge({client: true}, ejsOptions.compileOptions || {})) +
             "}).call(this);";
         } catch (e) {
             log.error('%s\n  at %s', e.message, content);
@@ -38,7 +38,7 @@ var createEjsPreprocessor = function(logger, basePath, ejsOptions) {
     };
 };
 
-createEjsPreprocessor.$inject = ['logger', 'config.basePath', 'config.ejsOptions'];
+createEjsPreprocessor.$inject = ['logger', 'helper', 'config.basePath', 'config.ejsOptions'];
 
 module.exports = {
     'preprocessor:ejs': ['factory', createEjsPreprocessor]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "karma-ejs-preprocessor",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "A Karma plugin. Compiles underscore embedded js templates.",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
This PR adds support for passing EJS compile options as listed in https://github.com/tj/ejs#options.

This may come in handy when certain asset files use helper functions that are not available and we want to define/reference those functions for use with karma. 

In my case assets were using the `asset_path` helper from [connect-assets](https://github.com/adunkman/connect-assets)), and I need this option so I can quickly mock the helper.

Note: closing this PR since I realized that EJS compile options changed a lot in EJS 2, and I was looking at EJS 1 :open_mouth: Will come up with another PR instead
